### PR TITLE
Check Null-safeness when switching optional-codecs state

### DIFF
--- a/src/com/android/bluetooth/a2dp/A2dpCodecConfig.java
+++ b/src/com/android/bluetooth/a2dp/A2dpCodecConfig.java
@@ -105,7 +105,7 @@ class A2dpCodecConfig {
         // Set the mandatory codec's priority to default, and remove the rest
         for (int i = 0; i < codecConfigArray.length; i++) {
             BluetoothCodecConfig codecConfig = codecConfigArray[i];
-            if (!codecConfig.isMandatoryCodec()) {
+            if (codecConfig != null && !codecConfig.isMandatoryCodec()) {
                 codecConfigArray[i] = null;
             }
         }
@@ -126,7 +126,7 @@ class A2dpCodecConfig {
         // Set the mandatory codec's priority to highest, and remove the rest
         for (int i = 0; i < codecConfigArray.length; i++) {
             BluetoothCodecConfig codecConfig = codecConfigArray[i];
-            if (codecConfig.isMandatoryCodec()) {
+            if (codecConfig != null && codecConfig.isMandatoryCodec()) {
                 codecConfig.setCodecPriority(BluetoothCodecConfig.CODEC_PRIORITY_HIGHEST);
             } else {
                 codecConfigArray[i] = null;


### PR DESCRIPTION
When checking the codecs type (if it was SBC or not), there's
a chance that they'll throw an NPE and fails to either raise
or lowering the SBC priority.

Bug:
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.bluetooth.BluetoothCodecConfig.isMandatoryCodec()' on a null object reference
	at com.android.bluetooth.a2dp.A2dpCodecConfig.enableOptionalCodecs(A2dpCodecConfig.java:108)
....
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.bluetooth.BluetoothCodecConfig.isMandatoryCodec()' on a null object reference
	at com.android.bluetooth.a2dp.A2dpCodecConfig.disableOptionalCodecs(A2dpCodecConfig.java:129)
....

Signed-off-by: Nauval Rizky <enuma.alrizky@gmail.com>